### PR TITLE
Always setting a PublicationDate object

### DIFF
--- a/src/main/java/no/unit/nva/doi/transformer/CrossRefConverter.java
+++ b/src/main/java/no/unit/nva/doi/transformer/CrossRefConverter.java
@@ -82,7 +82,7 @@ public class CrossRefConverter extends AbstractConverter {
                 .withFileSet(createFilseSet())
                 .withEntityDescription(new EntityDescription.Builder()
                     .withContributors(toContributors(document.getAuthor()))
-                    .withDate(extractDate(document).orElse(null))
+                    .withDate(extractDate(document).orElse(new PublicationDate()))
                     .withMainTitle(extractTitle(document))
                     .withAlternativeTitles(extractAlternativeTitles(document))
                     .withPublicationType(extractPublicationType(document))

--- a/src/test/java/no/unit/nva/doi/transformer/CrossRefConverterTest.java
+++ b/src/test/java/no/unit/nva/doi/transformer/CrossRefConverterTest.java
@@ -110,12 +110,12 @@ public class CrossRefConverterTest extends ConversionTest {
     }
 
     @Test
-    @DisplayName("toPublication sets null EntityDescription date when input has no \"published-print\" date")
-    public void entityDescriptionDateIsNullWhenInputDataHasNoPublicationDate() {
+    @DisplayName("toPublication sets empty EntityDescription date when input has no \"published-print\" date")
+    public void entityDescriptionDateIsEmptyWhenInputDataHasNoPublicationDate() {
         sampleInputDocument.setPublishedPrint(null);
         Publication publicationWithoutDate = toPublication(sampleInputDocument);
         PublicationDate actualDate = publicationWithoutDate.getEntityDescription().getDate();
-        assertThat(actualDate, is(nullValue()));
+        assertThat(actualDate, is(new PublicationDate()));
     }
 
     @Test


### PR DESCRIPTION
Do you agree this is the best solution? This fix gives it the same behavior as the DataciteConverter. The alternative is to have null values in backend and push responsibility to frontend.