### PR TITLE
Fix up to data model 0.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: '1.8.0-beta4') {
         because 'Used by org.apache.logging.log4j:log4j-slf4j18-impl:2.13.2 in nva-commons'
     }
-    implementation group: 'com.github.BIBSYSDEV', name: 'nva-datamodel-java', version: '0.8.1'
+    implementation group: 'com.github.BIBSYSDEV', name: 'nva-datamodel-java', version: '0.9.0'
     implementation group: 'com.github.BIBSYSDEV', name: 'nva-commons', version: '0.3.4'
     implementation(group: 'com.ibm.icu', name: 'icu4j', version: '66.1') {
         because 'We use this to map ordinals to numbers'

--- a/src/main/java/no/unit/nva/doi/transformer/CrossRefConverter.java
+++ b/src/main/java/no/unit/nva/doi/transformer/CrossRefConverter.java
@@ -43,6 +43,7 @@ import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.MalformedContributorException;
 import no.unit.nva.model.instancetypes.JournalArticle;
 import no.unit.nva.model.instancetypes.PublicationInstance;
+import no.unit.nva.model.pages.Pages;
 import no.unit.nva.model.pages.Range;
 import nva.commons.utils.attempt.Try;
 import nva.commons.utils.doi.DoiConverterImpl;
@@ -70,8 +71,9 @@ public class CrossRefConverter extends AbstractConverter {
      * @param identifier  the publication identifier.
      * @param publisherId the id for a publisher.
      * @return an internal representation of the publication.
-     * @throws InvalidIssnException     thrown if a provided ISSN is invalid.
-     *                                  type.
+     * @throws InvalidIssnException      thrown if a provided ISSN is invalid.
+     *                                   type.
+     * @throws InvalidPageRangeException thrown if page range is invalid.
      */
     public Publication toPublication(CrossRefDocument document,
                                      Instant now,
@@ -136,7 +138,7 @@ public class CrossRefConverter extends AbstractConverter {
 
     private Reference extractReference(CrossRefDocument document) throws InvalidIssnException,
                                                                          InvalidPageRangeException {
-        PublicationInstance<?> instance = extractPublicationInstance(document);
+        PublicationInstance<? extends Pages> instance = extractPublicationInstance(document);
         BasicContext context = extractPublicationContext(document);
         return new Reference.Builder()
             .withDoi(doiConverter.toUri(document.getDoi()))
@@ -188,7 +190,7 @@ public class CrossRefConverter extends AbstractConverter {
             .orElse(null);
     }
 
-    private PublicationInstance<?> extractPublicationInstance(CrossRefDocument document) throws
+    private PublicationInstance<? extends Pages> extractPublicationInstance(CrossRefDocument document) throws
             InvalidPageRangeException {
         return new JournalArticle.Builder()
             .withVolume(document.getVolume())

--- a/src/main/java/no/unit/nva/doi/transformer/CrossRefConverter.java
+++ b/src/main/java/no/unit/nva/doi/transformer/CrossRefConverter.java
@@ -9,6 +9,7 @@ import no.unit.nva.doi.transformer.model.crossrefmodel.CrossrefDate;
 import no.unit.nva.doi.transformer.model.crossrefmodel.Issn;
 import no.unit.nva.doi.transformer.utils.CrossrefType;
 import no.unit.nva.doi.transformer.utils.IssnCleaner;
+import no.unit.nva.doi.transformer.utils.PublicationType;
 import no.unit.nva.doi.transformer.utils.StringUtils;
 import no.unit.nva.doi.transformer.utils.TextLang;
 import no.unit.nva.model.Contributor;
@@ -17,13 +18,12 @@ import no.unit.nva.model.FileSet;
 import no.unit.nva.model.Identity;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.PublicationDate;
-import no.unit.nva.model.PublicationType;
 import no.unit.nva.model.Reference;
 import no.unit.nva.model.ResearchProject;
+import no.unit.nva.model.contexttypes.BasicContext;
 import no.unit.nva.model.contexttypes.Journal;
-import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.exceptions.InvalidIssnException;
-import no.unit.nva.model.exceptions.InvalidPageTypeException;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.MalformedContributorException;
 import no.unit.nva.model.instancetypes.JournalArticle;
 import no.unit.nva.model.instancetypes.PublicationInstance;
@@ -73,14 +73,13 @@ public class CrossRefConverter extends AbstractConverter {
      * @param publisherId the id for a publisher.
      * @return an internal representation of the publication.
      * @throws InvalidIssnException     thrown if a provided ISSN is invalid.
-     * @throws InvalidPageTypeException thrown if the provided page type is incompatible with
      *                                  the publication instance type.
      */
     public Publication toPublication(CrossRefDocument document,
                                      Instant now,
                                      String owner,
                                      UUID identifier,
-                                     URI publisherId) throws InvalidIssnException, InvalidPageTypeException {
+                                     URI publisherId) throws InvalidIssnException, InvalidPageRangeException {
 
         if (document != null && hasTitle(document)) {
             return new Publication.Builder()
@@ -138,9 +137,9 @@ public class CrossRefConverter extends AbstractConverter {
     }
 
     private Reference extractReference(CrossRefDocument document) throws InvalidIssnException,
-            InvalidPageTypeException {
-        PublicationInstance instance = extractPublicationInstance(document);
-        PublicationContext context = extractPublicationContext(document);
+            InvalidPageRangeException {
+        PublicationInstance<?> instance = extractPublicationInstance(document);
+        BasicContext context = extractPublicationContext(document);
         return new Reference.Builder()
             .withDoi(doiConverter.toUri(document.getDoi()))
             .withPublishingContext(context)
@@ -148,11 +147,11 @@ public class CrossRefConverter extends AbstractConverter {
             .build();
     }
 
-    private Range extractPages(CrossRefDocument document) {
+    private Range extractPages(CrossRefDocument document) throws InvalidPageRangeException {
         return StringUtils.parsePage(document.getPage());
     }
 
-    private PublicationContext extractPublicationContext(CrossRefDocument document) throws InvalidIssnException {
+    private BasicContext extractPublicationContext(CrossRefDocument document) throws InvalidIssnException {
         CrossrefType crossrefType = CrossrefType.getByType(document.getType());
         PublicationType publicationType = crossrefType.getPublicationType();
 
@@ -190,7 +189,8 @@ public class CrossRefConverter extends AbstractConverter {
                 .collect(SingletonCollector.collect());
     }
 
-    private PublicationInstance extractPublicationInstance(CrossRefDocument document) throws InvalidPageTypeException {
+    private PublicationInstance<?> extractPublicationInstance(CrossRefDocument document) throws
+            InvalidPageRangeException {
         return new JournalArticle.Builder()
                 .withVolume(document.getVolume())
                 .withIssue(document.getIssue())

--- a/src/main/java/no/unit/nva/doi/transformer/DataciteResponseConverter.java
+++ b/src/main/java/no/unit/nva/doi/transformer/DataciteResponseConverter.java
@@ -46,6 +46,7 @@ import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.MalformedContributorException;
 import no.unit.nva.model.instancetypes.JournalArticle;
 import no.unit.nva.model.instancetypes.PublicationInstance;
+import no.unit.nva.model.pages.Pages;
 import no.unit.nva.model.pages.Range;
 import nva.commons.utils.doi.DoiConverterImpl;
 
@@ -127,7 +128,7 @@ public class DataciteResponseConverter extends AbstractConverter {
             .build();
     }
 
-    private PublicationInstance<?> extractPublicationInstance(DataciteResponse dataciteResponse) throws
+    private PublicationInstance<? extends Pages> extractPublicationInstance(DataciteResponse dataciteResponse) throws
             InvalidPageRangeException {
         if (JOURNAL_CONTENT.equals(extractPublicationType(dataciteResponse))) {
             DataciteContainer container = dataciteResponse.getContainer();

--- a/src/main/java/no/unit/nva/doi/transformer/DataciteResponseConverter.java
+++ b/src/main/java/no/unit/nva/doi/transformer/DataciteResponseConverter.java
@@ -13,6 +13,7 @@ import no.unit.nva.doi.transformer.utils.DataciteRelationType;
 import no.unit.nva.doi.transformer.utils.DataciteTypesUtil;
 import no.unit.nva.doi.transformer.utils.IssnCleaner;
 import no.unit.nva.doi.transformer.utils.LicensingIndicator;
+import no.unit.nva.doi.transformer.utils.PublicationType;
 import no.unit.nva.model.Contributor;
 import no.unit.nva.model.EntityDescription;
 import no.unit.nva.model.Identity;
@@ -20,13 +21,12 @@ import no.unit.nva.model.Level;
 import no.unit.nva.model.NameType;
 import no.unit.nva.model.Organization;
 import no.unit.nva.model.Publication;
-import no.unit.nva.model.PublicationType;
 import no.unit.nva.model.Reference;
 import no.unit.nva.model.ResearchProject;
+import no.unit.nva.model.contexttypes.BasicContext;
 import no.unit.nva.model.contexttypes.Journal;
-import no.unit.nva.model.contexttypes.PublicationContext;
 import no.unit.nva.model.exceptions.InvalidIssnException;
-import no.unit.nva.model.exceptions.InvalidPageTypeException;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.exceptions.MalformedContributorException;
 import no.unit.nva.model.instancetypes.JournalArticle;
 import no.unit.nva.model.instancetypes.PublicationInstance;
@@ -49,7 +49,7 @@ import java.util.stream.Stream;
 
 import static java.util.Objects.nonNull;
 import static java.util.function.Predicate.not;
-import static no.unit.nva.model.PublicationType.JOURNAL_CONTENT;
+import static no.unit.nva.doi.transformer.utils.PublicationType.JOURNAL_CONTENT;
 
 public class DataciteResponseConverter extends AbstractConverter {
 
@@ -69,12 +69,12 @@ public class DataciteResponseConverter extends AbstractConverter {
      * @param owner            owner
      * @return publication
      * @throws URISyntaxException       when dataciteResponse contains invalid URIs
-     * @throws InvalidPageTypeException when the mapping uses an incorrect page type related to the PublicationContext
+     * @throws InvalidPageRangeException when the mapping uses an incorrect page type related to the PublicationContext
      * @throws InvalidIssnException     when the ISSN is invalid
      */
     public Publication toPublication(DataciteResponse dataciteResponse, Instant now, UUID identifier, String owner,
-                                     URI publisherId) throws URISyntaxException, InvalidPageTypeException,
-            InvalidIssnException {
+                                     URI publisherId) throws URISyntaxException, InvalidIssnException,
+            InvalidPageRangeException {
 
         return new Publication.Builder()
                 .withCreatedDate(now)
@@ -120,8 +120,8 @@ public class DataciteResponseConverter extends AbstractConverter {
         return null;
     }
 
-    private Reference createReference(DataciteResponse dataciteResponse) throws InvalidPageTypeException,
-            InvalidIssnException {
+    private Reference createReference(DataciteResponse dataciteResponse) throws InvalidIssnException,
+            InvalidPageRangeException {
         return new Reference.Builder()
                 .withDoi(doiConverter.toUri(dataciteResponse.getDoi()))
                 .withPublishingContext(extractPublicationContext(dataciteResponse))
@@ -129,8 +129,8 @@ public class DataciteResponseConverter extends AbstractConverter {
                 .build();
     }
 
-    private PublicationInstance extractPublicationInstance(DataciteResponse dataciteResponse) throws
-            InvalidPageTypeException {
+    private PublicationInstance<?> extractPublicationInstance(DataciteResponse dataciteResponse) throws
+            InvalidPageRangeException {
         if (JOURNAL_CONTENT.equals(extractPublicationType(dataciteResponse))) {
             DataciteContainer container = dataciteResponse.getContainer();
             String issue = Optional.ofNullable(container.getIssue()).orElse(null);
@@ -146,14 +146,14 @@ public class DataciteResponseConverter extends AbstractConverter {
         return null;
     }
 
-    private Range extractPages(DataciteContainer container) {
+    private Range extractPages(DataciteContainer container) throws InvalidPageRangeException {
         return new Range.Builder()
                 .withBegin(container.getFirstPage())
                 .withEnd(container.getLastPage())
                 .build();
     }
 
-    private PublicationContext extractPublicationContext(DataciteResponse dataciteResponse) throws
+    private BasicContext extractPublicationContext(DataciteResponse dataciteResponse) throws
             InvalidIssnException {
         PublicationType type = extractPublicationType(dataciteResponse);
         if (nonNull(type) && type.equals(JOURNAL_CONTENT)) {

--- a/src/main/java/no/unit/nva/doi/transformer/PublicationTransformer.java
+++ b/src/main/java/no/unit/nva/doi/transformer/PublicationTransformer.java
@@ -16,7 +16,7 @@ import no.unit.nva.doi.transformer.model.crossrefmodel.CrossrefApiResponse;
 import no.unit.nva.doi.transformer.model.internal.external.DataciteResponse;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.exceptions.InvalidIssnException;
-import no.unit.nva.model.exceptions.InvalidPageTypeException;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.util.OrgNumberMapper;
 
 public class PublicationTransformer {
@@ -57,16 +57,16 @@ public class PublicationTransformer {
      * @param body            the request body as extracted from the event.
      * @param contentLocation crossref or datacite.
      * @return a Publication.
-     * @throws JsonProcessingException  when cannot process json.
+     * @throws JsonProcessingException   when cannot process json.
      * @throws MissingClaimException     when request does not have the required claims.
-     * @throws URISyntaxException       when the input contains invalid URIs
-     * @throws InvalidIssnException     thrown if a provided ISSN is invalid.
-     * @throws InvalidPageTypeException thrown if the provided page type is incompatible with
-     *                                  the publication instance type.
+     * @throws URISyntaxException        when the input contains invalid URIs
+     * @throws InvalidIssnException      thrown if a provided ISSN is invalid.
+     * @throws InvalidPageRangeException thrown if the provided page type is incompatible with
+     *                                   the publication instance type.
      */
     public Publication transformPublication(JsonNode event, String body, String contentLocation)
             throws JsonProcessingException, MissingClaimException, URISyntaxException, InvalidIssnException,
-            InvalidPageTypeException {
+            InvalidPageRangeException {
         String owner = getClaimValueFromRequestContext(event, CUSTOM_FEIDE_ID);
         String orgNumber = getClaimValueFromRequestContext(event, CUSTOM_ORG_NUMBER);
         UUID uuid = UUID.randomUUID();
@@ -77,7 +77,7 @@ public class PublicationTransformer {
 
     protected Publication convertInputToPublication(String body, String contentLocation, Instant now, String owner,
                                                     UUID identifier, URI publisher)
-            throws JsonProcessingException, URISyntaxException, InvalidIssnException, InvalidPageTypeException {
+            throws JsonProcessingException, URISyntaxException, InvalidIssnException, InvalidPageRangeException {
 
         MetadataLocation metadataLocation = MetadataLocation.lookup(contentLocation);
         if (metadataLocation.equals(MetadataLocation.CROSSREF)) {
@@ -88,13 +88,13 @@ public class PublicationTransformer {
     }
 
     private Publication convertFromDatacite(String body, Instant now, String owner, UUID uuid, URI publisherId)
-            throws JsonProcessingException, URISyntaxException, InvalidPageTypeException, InvalidIssnException {
+            throws JsonProcessingException, URISyntaxException, InvalidIssnException, InvalidPageRangeException {
         DataciteResponse dataciteResponse = objectMapper.readValue(body, DataciteResponse.class);
         return dataciteConverter.toPublication(dataciteResponse, now, uuid, owner, publisherId);
     }
 
     private Publication convertFromCrossRef(String body, Instant now, String owner, UUID identifier, URI publisherId)
-            throws JsonProcessingException, InvalidIssnException, InvalidPageTypeException {
+            throws JsonProcessingException, InvalidIssnException, InvalidPageRangeException {
 
         CrossRefDocument document = objectMapper.readValue(body, CrossrefApiResponse.class).getMessage();
         return crossRefConverter.toPublication(document, now, owner, identifier, publisherId);

--- a/src/main/java/no/unit/nva/doi/transformer/utils/BibTexType.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/BibTexType.java
@@ -1,6 +1,5 @@
 package no.unit.nva.doi.transformer.utils;
 
-import no.unit.nva.model.PublicationType;
 import nva.commons.utils.SingletonCollector;
 
 import java.util.Arrays;

--- a/src/main/java/no/unit/nva/doi/transformer/utils/CiteProcType.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/CiteProcType.java
@@ -1,6 +1,5 @@
 package no.unit.nva.doi.transformer.utils;
 
-import no.unit.nva.model.PublicationType;
 import nva.commons.utils.SingletonCollector;
 
 import java.util.Arrays;

--- a/src/main/java/no/unit/nva/doi/transformer/utils/CrossrefType.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/CrossrefType.java
@@ -1,6 +1,5 @@
 package no.unit.nva.doi.transformer.utils;
 
-import no.unit.nva.model.PublicationType;
 import nva.commons.utils.SingletonCollector;
 
 import java.util.Arrays;

--- a/src/main/java/no/unit/nva/doi/transformer/utils/DataciteTypesUtil.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/DataciteTypesUtil.java
@@ -2,7 +2,6 @@ package no.unit.nva.doi.transformer.utils;
 
 import no.unit.nva.doi.transformer.model.internal.external.DataciteResponse;
 import no.unit.nva.doi.transformer.model.internal.external.DataciteTypes;
-import no.unit.nva.model.PublicationType;
 import nva.commons.utils.SingletonCollector;
 
 import java.util.ArrayList;

--- a/src/main/java/no/unit/nva/doi/transformer/utils/PublicationType.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/PublicationType.java
@@ -1,0 +1,5 @@
+package no.unit.nva.doi.transformer.utils;
+
+public enum PublicationType {
+    JOURNAL_CONTENT
+}

--- a/src/main/java/no/unit/nva/doi/transformer/utils/RisType.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/RisType.java
@@ -1,6 +1,5 @@
 package no.unit.nva.doi.transformer.utils;
 
-import no.unit.nva.model.PublicationType;
 import nva.commons.utils.SingletonCollector;
 
 import java.util.Arrays;

--- a/src/main/java/no/unit/nva/doi/transformer/utils/SchemaOrgType.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/SchemaOrgType.java
@@ -1,6 +1,5 @@
 package no.unit.nva.doi.transformer.utils;
 
-import no.unit.nva.model.PublicationType;
 import nva.commons.utils.SingletonCollector;
 
 import java.util.Arrays;

--- a/src/main/java/no/unit/nva/doi/transformer/utils/StringUtils.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/StringUtils.java
@@ -14,6 +14,8 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.pages.Range;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -99,7 +101,7 @@ public final class StringUtils {
      * @param pages A "pages" string
      * @return A {@link Range} object with the respective pages.
      */
-    public static Range parsePage(String pages) {
+    public static Range parsePage(String pages) throws InvalidPageRangeException {
         if (pages == null) {
             return null;
         }
@@ -113,6 +115,8 @@ public final class StringUtils {
             start = array[0];
             if (hasSecondArg(array)) {
                 end = array[1];
+            } else {
+                end = array[0];
             }
         }
         return new Range.Builder().withBegin(start).withEnd(end).build();

--- a/src/main/java/no/unit/nva/doi/transformer/utils/StringUtils.java
+++ b/src/main/java/no/unit/nva/doi/transformer/utils/StringUtils.java
@@ -100,6 +100,7 @@ public final class StringUtils {
      *
      * @param pages A "pages" string
      * @return A {@link Range} object with the respective pages.
+     * @throws InvalidPageRangeException If the page range is invalid.
      */
     public static Range parsePage(String pages) throws InvalidPageRangeException {
         if (pages == null) {

--- a/src/test/java/no/unit/nva/doi/transformer/CrossRefConverterTest.java
+++ b/src/test/java/no/unit/nva/doi/transformer/CrossRefConverterTest.java
@@ -256,7 +256,8 @@ public class CrossRefConverterTest extends ConversionTest {
 
     @Test
     @DisplayName("toPublication sets the issue of the Reference when the Crosref document has a \"Issue\" value")
-    public void toPublicationSetsTheIssueOfTheReferenceWhentheCrossrefDocHasAnIssueValue() throws InvalidIssnException, InvalidPageRangeException {
+    public void toPublicationSetsTheIssueOfTheReferenceWhentheCrossrefDocHasAnIssueValue() throws InvalidIssnException,
+            InvalidPageRangeException {
         String expectedIssue = "SomeIssue";
 
         sampleInputDocument.setIssue(expectedIssue);

--- a/src/test/java/no/unit/nva/doi/transformer/DataciteResponseConverterTest.java
+++ b/src/test/java/no/unit/nva/doi/transformer/DataciteResponseConverterTest.java
@@ -22,7 +22,7 @@ import no.unit.nva.doi.transformer.model.internal.external.DataciteCreator;
 import no.unit.nva.doi.transformer.model.internal.external.DataciteResponse;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.exceptions.InvalidIssnException;
-import no.unit.nva.model.exceptions.InvalidPageTypeException;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import nva.commons.utils.IoUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +39,7 @@ public class DataciteResponseConverterTest {
     @DisplayName("DataciteResponseConverter::toPublication returns valid JSON when input is valid")
     @Test
     public void toPublicationReturnsValidJsonWhenInputIsValid() throws IOException, URISyntaxException,
-            InvalidPageTypeException, InvalidIssnException {
+            InvalidIssnException, InvalidPageRangeException {
 
         DataciteResponse dataciteResponse = objectMapper.readValue(
             new File("src/test/resources/datacite_response.json"), DataciteResponse.class);
@@ -68,7 +68,7 @@ public class DataciteResponseConverterTest {
     @DisplayName("Publication contains alternativeTitles with non null langauge tags when datacite document has "
         + "many titles")
     public void publicationContainsAlternativeTitlesWithNonNullLanguageTagsWhenDatataciteDocumentHasManyTitles()
-            throws IOException, URISyntaxException, InvalidPageTypeException, InvalidIssnException {
+            throws IOException, URISyntaxException, InvalidIssnException, InvalidPageRangeException {
         Publication publication = readPublicationWithMutlipleTitles();
         Map<String, String> alternativeTitles = publication.getEntityDescription().getAlternativeTitles();
         Collection<String> languageTags = alternativeTitles.values();
@@ -79,7 +79,7 @@ public class DataciteResponseConverterTest {
     @DisplayName("Publication does not contain the main title in the alternative titles when the datacite document"
         + " has many titles")
     public void publicationDoesNotContainMainTitleInAlternativeTItleWhenDataciteDocHasManyTitles()
-            throws IOException, URISyntaxException, InvalidPageTypeException, InvalidIssnException {
+            throws IOException, URISyntaxException, InvalidIssnException, InvalidPageRangeException {
         Publication publication = readPublicationWithMutlipleTitles();
         String mainTitle = publication.getEntityDescription().getMainTitle();
         Set<String> altTitles = publication.getEntityDescription().getAlternativeTitles().keySet();
@@ -90,7 +90,7 @@ public class DataciteResponseConverterTest {
     @DisplayName("Publication contains alternative titles with valid language URIs when the datacite document has "
         + " many titles")
     public void publicationContainsAlternativeTtitlesWithValidLanguageURisWhenDataciteDocHasManyTitles()
-            throws IOException, URISyntaxException, InvalidPageTypeException, InvalidIssnException {
+            throws IOException, URISyntaxException, InvalidIssnException, InvalidPageRangeException {
         Publication publication = readPublicationWithMutlipleTitles();
         Map<String, String> alternativeTitles = publication.getEntityDescription().getAlternativeTitles();
         Collection<String> languageTags = alternativeTitles.values();
@@ -102,7 +102,7 @@ public class DataciteResponseConverterTest {
     }
 
     private Publication readPublicationWithMutlipleTitles() throws IOException, URISyntaxException,
-            InvalidPageTypeException, InvalidIssnException {
+            InvalidIssnException, InvalidPageRangeException {
         String input = IoUtils.stringFromResources(Path.of(ENTRY_WITH_ALTERNATIVE_TITLE));
         DataciteResponseConverter converter = new DataciteResponseConverter();
         DataciteResponse response = objectMapper.readValue(input, DataciteResponse.class);

--- a/src/test/java/no/unit/nva/doi/transformer/MainHandlerTest.java
+++ b/src/test/java/no/unit/nva/doi/transformer/MainHandlerTest.java
@@ -39,7 +39,7 @@ import no.unit.nva.doi.transformer.model.internal.external.DataciteResponse;
 import no.unit.nva.doi.transformer.utils.TestLambdaLogger;
 import no.unit.nva.model.Publication;
 import no.unit.nva.model.exceptions.InvalidIssnException;
-import no.unit.nva.model.exceptions.InvalidPageTypeException;
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import nva.commons.utils.IoUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.entity.ContentType;
@@ -96,8 +96,8 @@ public class MainHandlerTest extends ConversionTest {
     }
 
     @Test
-    public void testInternalServerErrorResponse() throws IOException, URISyntaxException, InvalidPageTypeException,
-            InvalidIssnException {
+    public void testInternalServerErrorResponse() throws IOException, URISyntaxException, InvalidIssnException,
+            InvalidPageRangeException {
         DataciteResponseConverter dataciteConverter = mock(DataciteResponseConverter.class);
         CrossRefConverter crossRefConverter = new CrossRefConverter();
 
@@ -116,7 +116,7 @@ public class MainHandlerTest extends ConversionTest {
 
     @Test
     public void convertInputToPublicationShouldParseCrossrefWhenMetadataLocationIsCrossRef()
-            throws IOException, URISyntaxException, InvalidIssnException, InvalidPageTypeException {
+            throws IOException, URISyntaxException, InvalidIssnException, InvalidPageRangeException {
 
         PublicationTransformer publicationTransformer = new PublicationTransformer();
         String jsonString = IoUtils.stringFromResources(Paths.get(SAMPLE_CROSSREF_FILE));
@@ -132,7 +132,7 @@ public class MainHandlerTest extends ConversionTest {
 
     @Test
     public void convertInputToPublicationShouldParseDataciteWhenMetadataLocationIsDatacite()
-            throws IOException, URISyntaxException, InvalidIssnException, InvalidPageTypeException {
+            throws IOException, URISyntaxException, InvalidIssnException, InvalidPageRangeException {
 
         PublicationTransformer transformer = new PublicationTransformer();
         String jsonString = IoUtils.stringFromResources(Paths.get(DATACITE_RESPONSE_JSON));
@@ -163,15 +163,15 @@ public class MainHandlerTest extends ConversionTest {
     }
 
     private Publication createPublicationUsingCrossRefConverterDirectly(String jsonString, Instant now)
-            throws com.fasterxml.jackson.core.JsonProcessingException, InvalidIssnException, InvalidPageTypeException {
+            throws com.fasterxml.jackson.core.JsonProcessingException, InvalidIssnException, InvalidPageRangeException {
         CrossRefDocument doc = objectMapper.readValue(jsonString, CrossrefApiResponse.class).getMessage();
         return new CrossRefConverter()
                 .toPublication(doc, now, SOME_OWNER, SOME_UUID, SOME_PUBLISHER_URI);
     }
 
     private Publication createPublicationUsingDataciteConverterDirectly(String jsonString, Instant now)
-            throws com.fasterxml.jackson.core.JsonProcessingException, URISyntaxException, InvalidPageTypeException,
-            InvalidIssnException {
+            throws com.fasterxml.jackson.core.JsonProcessingException, URISyntaxException, InvalidIssnException,
+            InvalidPageRangeException {
         DataciteResponse doc = objectMapper.readValue(jsonString, DataciteResponse.class);
         return new DataciteResponseConverter().toPublication(doc, now, SOME_UUID, SOME_OWNER, SOME_PUBLISHER_URI);
     }

--- a/src/test/java/no/unit/nva/doi/transformer/utils/DataciteTypesUtilTest.java
+++ b/src/test/java/no/unit/nva/doi/transformer/utils/DataciteTypesUtilTest.java
@@ -2,7 +2,6 @@ package no.unit.nva.doi.transformer.utils;
 
 import no.unit.nva.doi.transformer.model.internal.external.DataciteResponse;
 import no.unit.nva.doi.transformer.model.internal.external.DataciteTypes;
-import no.unit.nva.model.PublicationType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/no/unit/nva/doi/transformer/utils/StringUtilsTest.java
+++ b/src/test/java/no/unit/nva/doi/transformer/utils/StringUtilsTest.java
@@ -4,8 +4,10 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
+import no.unit.nva.model.exceptions.InvalidPageRangeException;
 import no.unit.nva.model.pages.Pages;
 import no.unit.nva.model.pages.Range;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +24,7 @@ public class StringUtilsTest {
 
     @Test
     @DisplayName("parsePage returns a begin and end apge for pages split with dash")
-    public void parsePageReturnsABeginAndEndPageForPagesSplitWithDash() {
+    public void parsePageReturnsABeginAndEndPageForPagesSplitWithDash() throws InvalidPageRangeException {
         String begins = "12";
         String ends = "34";
         String delimiter = "-";
@@ -33,17 +35,17 @@ public class StringUtilsTest {
     }
 
     @Test
-    @DisplayName("parsePage returns a \"begin\" without an \"end\" for page string with as single number")
-    public void parsePageReturnsABeginWithoutAnEndPageForPagesBeingASingleNumber() {
+    @DisplayName("parsePage returns a \"begin\" repeating \"begin\" for page string with as single number")
+    public void parsePageReturnsABeginWithoutAnEndPageForPagesBeingASingleNumber() throws InvalidPageRangeException {
         String pagesString = "12";
-        Pages expected = new Range.Builder().withBegin(pagesString).withEnd(null).build();
+        Pages expected = new Range.Builder().withBegin(pagesString).withEnd(pagesString).build();
         Pages actual = StringUtils.parsePage(pagesString);
         assertThat(actual, is(equalTo(expected)));
     }
 
     @Test
     @DisplayName("parsePage returns a \"begin\" and \"end\" for page strings that have prefix.")
-    public void parsePageReturnsABeginAndEndPageForPagesThatHaveAPrefix() {
+    public void parsePageReturnsABeginAndEndPageForPagesThatHaveAPrefix() throws InvalidPageRangeException {
         String prefix = "p.";
         String begins = "12";
         String ends = "34";
@@ -56,7 +58,8 @@ public class StringUtilsTest {
 
     @Test
     @DisplayName("parsePage returns a \"begin\" and \"end\" for page strings that have prefix word with space.")
-    public void parsePageReturnsABeginAndEndPageForPagesThatHaveAPrefixWordWithSpace() {
+    public void parsePageReturnsABeginAndEndPageForPagesThatHaveAPrefixWordWithSpace() throws
+            InvalidPageRangeException {
         String prefix = "pages ";
         String begins = "12";
         String ends = "34";


### PR DESCRIPTION
- A number of small fixes to make doi-transformer work with datamodel 0.9.0
- Page handling changes so that single-page articles are now 12-12
- Hack to fix type matching, this will need to be revisited in next update